### PR TITLE
Initialize `Afinn` on-demand

### DIFF
--- a/pre_commit_hooks/commit-msg-sentiment.py
+++ b/pre_commit_hooks/commit-msg-sentiment.py
@@ -58,8 +58,6 @@ def reject_commit():
 def accept_commit():
     sys.exit(0)
 
-afinn = Afinn()
-
 ############################# BEGIN MAIN SCRIPT ################################
 
 # Get commit message from file or stdin
@@ -73,6 +71,7 @@ else:
 # for short commit messages, use Afinn to get sentiment polarity score (uses a
 # modified threshold, to avoid false positives for short messages)
 if len(commit_msg) < min_commit_msg_length:
+    afinn = Afinn()
     sentiment_score = afinn.score(commit_msg)
     if sentiment_score < (threshold-1):
         reject_commit()


### PR DESCRIPTION
Moves the initialization of `Afinn` to only before it's used. This prevents import side-effects. Import side-effects are undesirable because it reduces readability, predictability, makes testing harder, and slows down performance.